### PR TITLE
loader.cpp: Fix plugin suffix for Qt6

### DIFF
--- a/core/loader.cpp
+++ b/core/loader.cpp
@@ -55,7 +55,11 @@ Loader& Loader::instance()
 
 #define PLUGIN_PREFIX_ENV "SENSORFW_LIBRARY_PATH"
 #define PLUGIN_PREFIX     "lib"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#define PLUGIN_SUFFIX     "-qt6.so"
+#else
 #define PLUGIN_SUFFIX     "-qt5.so"
+#endif
 #define SENSOR_SUFFIX     "sensor"
 
 static QString getPluginDirectory()


### PR DESCRIPTION
@jmlich Thanks for this nicer and cleaner update with Qt6 compatibility! 

On LuneOS while testing this (we used a hackidy hack patched sensorfw before https://github.com/webOS-ports/sensorfw/tree/herrie/qt6) we ran into plugins not being loaded (correctly).

There were 2 reasons:
1. Suffix of -qt5 which is addressed by this patch

2. Incorrect path for QT_INSTALL_LIBS which might be LuneOS specific, so not sending a patch for that (yet). We had a similar issue with QT_INSTALL_LIBS for VoiceCall previously at our end. It would be good to clarify if it's indeed LuneOS specific or a generic issue that should be addressed. We've introduced QT6_INSTALL_LIBDIR at our end to solve this as per: https://github.com/Tofee/meta-webos-ports/commit/e8c88681a597b76041ce5314338976e4ec9ebb10

@Tofee did all the hard debugging, just PR-ing it here to unify work :)